### PR TITLE
3주차 과제 D. useState > Batch 구현

### DIFF
--- a/packages/chapter2/src/hooks2.js
+++ b/packages/chapter2/src/hooks2.js
@@ -1,4 +1,3 @@
-
 export function createHooks(callback) {
   const stateContext = {
     current: 0,
@@ -24,7 +23,8 @@ export function createHooks(callback) {
     const setState = (newState) => {
       if (newState === states[current]) return;
       states[current] = newState;
-      callback();
+      // 여기에서 requestAnimationFrame을 사용하여 비동기적으로 callback을 호출합니다.
+      requestAnimationFrame(callback);
     };
 
     return [states[current], setState];

--- a/packages/chapter2/src/hooks2.js
+++ b/packages/chapter2/src/hooks2.js
@@ -1,7 +1,9 @@
 export function createHooks(callback) {
+  let frameId = null; // 상태 변경을 위한 requestAnimationFrame의 ID
   const stateContext = {
     current: 0,
     states: [],
+    updateQueue: [], // 상태 변경 요청을 저장하는 큐
   };
 
   const memoContext = {
@@ -9,25 +11,49 @@ export function createHooks(callback) {
     memos: [],
   };
 
+  function processQueue() {
+    const { updateQueue, states } = stateContext;
+    // 상태 업데이트 큐를 처리합니다.
+    updateQueue.forEach(({ index, newState }) => {
+      states[index] = newState;
+    });
+    stateContext.updateQueue = []; // 큐를 비웁니다.
+
+    callback(); // 상태 변경 후 콜백(렌더링)을 호출합니다.
+    console.log('렌더링 발생');
+    frameId = null; // ID 초기화
+  }
+
   function resetContext() {
     stateContext.current = 0;
     memoContext.current = 0;
+    stateContext.updateQueue = [];
+    if (frameId !== null) {
+      cancelAnimationFrame(frameId);
+      frameId = null;
+    }
   }
 
   const useState = (initState) => {
-    const { current, states } = stateContext;
-    stateContext.current += 1;
-
-    states[current] = states[current] ?? initState;
+    const { states, updateQueue } = stateContext;
+    let index = stateContext.current++; // 현재 상태의 인덱스를 할당하고, 다음 상태를 위해 current를 증가시킵니다.
+    states[index] = states[index] ?? initState; // 초기 상태 할당 (이미 존재하는 경우 이전 상태 유지)
 
     const setState = (newState) => {
-      if (newState === states[current]) return;
-      states[current] = newState;
-      // 여기에서 requestAnimationFrame을 사용하여 비동기적으로 callback을 호출합니다.
-      requestAnimationFrame(callback);
+      // 새로운 상태 업데이트를 큐에 추가합니다. 동일 인덱스의 이전 업데이트는 제거합니다.
+      stateContext.updateQueue = updateQueue.filter(
+        (update) => update.index !== index,
+      );
+      stateContext.updateQueue.push({ index, newState });
+
+      // 이미 예약된 업데이트가 있다면 새로 예약하지 않습니다.
+      if (frameId !== null) return;
+
+      // 상태 변경을 위한 requestAnimationFrame을 예약합니다.
+      frameId = requestAnimationFrame(processQueue);
     };
 
-    return [states[current], setState];
+    return [states[index], setState];
   };
 
   const useMemo = (fn, refs) => {


### PR DESCRIPTION
## 결과
![스크린샷 2024-04-06 오전 1 49 15](https://github.com/lee-ji-hong/front1_chap1/assets/88364280/37ae2611-afc2-44c6-801c-4c19e5786c9c)

## 테스트 케이스

### TC1 : setState를 실행할 경우, 1frame 후에 callback이 다시 실행된다.

![스크린샷 2024-04-06 오전 1 48 02](https://github.com/lee-ji-hong/front1_chap1/assets/88364280/87dfd1b2-dbe6-475d-89d3-e3ec3ba7e6f5)

- requestAnimationFrame을 사용하여 비동기적으로 callback을 호출합니다.
- 상태 변경 후 화면이 업데이트되는 과정을 비동기적으로 처리하여, repaint가 이벤트루프에서 스케줄링 되기 직전에 실행되도록 합니다. 이는 브라우저가 효율적으로 화면을 그리도록 도와줍니다.

### TC2 : setState가 동시에 여러번 실행될 경우, 마지막 setState에 대해서만 render가 호출된다.
```js
let frameId = null; // 상태 변경을 위한 requestAnimationFrame의 ID
const stateContext = {
  current: 0,
  states: [],
  updateQueue: [], // 상태 변경 요청을 저장하는 큐
};

const memoContext = {
  current: 0,
  memos: [],
};
function processQueue() {
  const { updateQueue, states } = stateContext;
  // 상태 업데이트 큐를 처리합니다.
  updateQueue.forEach(({ index, newState }) => {
    states[index] = newState;
  });
  stateContext.updateQueue = []; // 큐를 비웁니다.

  callback(); // 상태 변경 후 콜백(렌더링)을 호출합니다.
  console.log('렌더링 발생');
  frameId = null; // ID 초기화
}

const useState = (initState) => {
  const { states, updateQueue } = stateContext;
  let index = stateContext.current++; // 현재 상태의 인덱스를 할당하고, 다음 상태를 위해 current를 증가시킵니다.
  states[index] = states[index] ?? initState; // 초기 상태 할당 (이미 존재하는 경우 이전 상태 유지)

  const setState = (newState) => {
    // 새로운 상태 업데이트를 큐에 추가합니다. 동일 인덱스의 이전 업데이트는 제거합니다.
    stateContext.updateQueue = updateQueue.filter(
      (update) => update.index !== index,
    );
    stateContext.updateQueue.push({ index, newState });

    // 이미 예약된 업데이트가 있다면 새로 예약하지 않습니다.
    if (frameId !== null) return;

    // 상태 변경을 위한 requestAnimationFrame을 예약합니다.
    frameId = requestAnimationFrame(processQueue);
  };

  return [states[index], setState];
};

```
- Fiber Architecture를 따라 구현하려고 해봤습니다..
- 상태 변경을 지연 실행하여 한 번에 업데이트하고, 상태 변경이 빈번히 발생하는 상황에서도 불필요한 렌더링을 줄이고, 최적화된 방식으로 상태 업데이트와 렌더링이 이루어지도록 합니다.
- setState 호출 시, 상태 변경을 위한 요청을 updateQueue에 추가합니다. 만약 동일한 인덱스에 대한 요청이 이미 큐에 있으면, 이를 먼저 제거하고 새 요청을 추가합니다. 이로써 동일한 상태에 대한 여러 변경 요청 중 마지막 요청만이 큐에 남게 됩니다.
- 상태 변경 요청이 큐에 추가될 때, 이미 예약된 requestAnimationFrame이 없는 경우에만 새로운 requestAnimationFrame을 예약합니다. 이는 상태 변경이 여러 번 발생해도 processQueue 함수가 단 한 번만 호출되도록 보장합니다.
- processQueue 함수는 큐에 있는 모든 상태 변경 요청을 처리하고, 최종 상태를 기반으로 한 번만 콜백(렌더링)을 호출합니다.